### PR TITLE
Add Custom Filename Input for Recordings

### DIFF
--- a/src/neon_gui/gui.py
+++ b/src/neon_gui/gui.py
@@ -13,6 +13,7 @@ from PyQt6.QtWidgets import (
     QGroupBox,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
     QMainWindow,
     QMessageBox,
     QPushButton,
@@ -62,6 +63,7 @@ class NeonGUI(QMainWindow):
         super().__init__()
         self.recorder = NeonRecorder()
         self.save_directory = os.path.expanduser("~/Desktop")
+        self.default_filename_schema = "scene_recording_{timestamp}"
         self.setup_ui()
         self.setup_timer()
         
@@ -127,6 +129,15 @@ class NeonGUI(QMainWindow):
         dir_layout.addWidget(self.browse_btn)
         
         recording_layout.addLayout(dir_layout)
+        
+        # Filename schema input
+        filename_label = QLabel("Filename (use {timestamp} for auto-timestamp):")
+        recording_layout.addWidget(filename_label)
+        
+        self.filename_input = QLineEdit()
+        self.filename_input.setText(self.default_filename_schema)
+        self.filename_input.setPlaceholderText("e.g., scene_recording_{timestamp}")
+        recording_layout.addWidget(self.filename_input)
         
         # Recording buttons
         self.start_btn = QPushButton("Start Recording")
@@ -227,11 +238,20 @@ class NeonGUI(QMainWindow):
     def start_recording(self):
         """Start recording."""
         try:
-            # Generate filename
+            # Generate filename from user input or default schema
+            filename_schema = self.filename_input.text().strip()
+            if not filename_schema:
+                filename_schema = self.default_filename_schema
+            
+            # Replace {timestamp} placeholder with actual timestamp
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            filename = os.path.join(
-                self.save_directory, f"scene_recording_{timestamp}.mp4"
-            )
+            filename_base = filename_schema.replace("{timestamp}", timestamp)
+            
+            # Add .mp4 extension if not present
+            if not filename_base.endswith(".mp4"):
+                filename_base += ".mp4"
+            
+            filename = os.path.join(self.save_directory, filename_base)
             
             self.recorder.start_recording(filename)
             


### PR DESCRIPTION
## Description

This PR adds the ability for users to customize the output filename for scene recordings. Previously, filenames were hardcoded as `scene_recording_{timestamp}.mp4`. Now users can enter their own filename schema with support for automatic timestamp insertion.

## Changes

- Added `QLineEdit` input field to the Recording control panel
- Implemented default filename schema: `scene_recording_{timestamp}`
- Added support for `{timestamp}` placeholder that gets replaced with actual timestamp (`YYYYMMDD_HHMMSS`)
- Automatic `.mp4` extension appending if not provided by user

## Usage

Users can now:
- Enter custom filenames like `my_experiment_{timestamp}` → `my_experiment_20260202_143052.mp4`
- Use static names like `recording` → `recording.mp4`
- Leave the field with the default schema `scene_recording_{timestamp}` → `scene_recording_20260202_143052.mp4`

## Related Issues

Resolves #1 
